### PR TITLE
Remove managers from profiler view

### DIFF
--- a/Resources/views/Profiler/profiler.html.twig
+++ b/Resources/views/Profiler/profiler.html.twig
@@ -118,14 +118,6 @@
 {% block panel %}
     <h2>Queries</h2>
     {{ block('queries') }}
-    <h2>Managers</h2>
-    {% if collector.managers %}
-        {% include '@WebProfiler/Profiler/table.html.twig' with {data: collector.managers} only %}
-    {% else %}
-        <p>
-            <em>No managers.</em>
-        </p>
-    {% endif %}
 
     <script type="text/javascript">//<![CDATA[
         function expandQuery(link) {


### PR DESCRIPTION
It seems that managers were deleted in 7.x, but they're still used in this file which causes a crash when opening the profiler page for Elasticsearch